### PR TITLE
Reuse the 'Check your email' pattern from Apply for Teacher Training

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@ $govuk-assets-path: "/govuk/assets/";
 @import "govuk-prototype-rig/rig/all";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
+@import "components/hidden-link";

--- a/app/assets/stylesheets/components/_hidden-link.scss
+++ b/app/assets/stylesheets/components/_hidden-link.scss
@@ -1,0 +1,6 @@
+// Hidden link
+
+.app-hidden-link {
+  color: inherit !important;
+  text-decoration: none;
+}

--- a/app/views/wizard/check-your-email.njk
+++ b/app/views/wizard/check-your-email.njk
@@ -1,14 +1,7 @@
 {% extends "layouts/default.njk" %}
 
-{% set title = "Find your TRN" %}
+{% set title = "Check your email to continue" %}
 
-{% block pageNavigation %}
-  {{ govukBackLink({
-    href: paths.back
-  }) }}
-{% endblock %}
-
-{% set title = "Check your email"%}
 {% set text %}
 # We've sent you a link to confirm your email address
 
@@ -24,7 +17,11 @@ If you do not get an email:
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {{ text | govukMarkdown | safe }}
+      <h1 class='govuk-heading-xl'>Check your email to continue</h1>
+
+      <p class='govuk-body'><a class="app-hidden-link" href="{{ paths.next }}">We’ve sent a sign in link to {{ data['email-address'] or 'your-email@domain.com' }}</a>.</p>
+
+      <p>If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="{{ paths.back }}">try again</a>.</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23801/142019124-cacf0f66-9186-48c6-b08e-f9a17dc2a0c8.png)

* The "We've sent you a sign in link" is a hidden link.
* Removed the 'back' link because it doesn't really make sense to go back on this screen