### PR TITLE
Fix some bugs around form data display and persistence

### DIFF
--- a/app/views/check-answers.njk
+++ b/app/views/check-answers.njk
@@ -63,7 +63,7 @@
             text: "Teacher training provider"
           },
           value: {
-            text: data['itt-provider']
+            text: data['former-itt-provider'] or data['current-itt-provider']
           },
           actions: {
             items: [{
@@ -72,8 +72,8 @@
               href: "/itt-provider"
             }]
           }
-        } if data['itt-provider']]
-      }) }}
+        } if data['former-itt-provider'] or data['current-itt-provider']
+      ]}) }}
 
       <h2 class="govuk-heading-m">If your answers are correct, you can submit a helpdesk request</h2>
       <p>By submitting this request you are confirming that, to the best of your knowledge, the details you are providing are correct. You will receive a response via email within 5 working days.</p>

--- a/app/views/itt-provider.njk
+++ b/app/views/itt-provider.njk
@@ -9,13 +9,23 @@
 {% endblock %}
 
 {% block content %}
-  {% set ittProviderNameHtml %}
+  {% set formerITTProviderNameHtml %}
     {{ govukInput({
       label: {
         text: "Your school, university or other training provider"
       },
-      id: "itt-provider",
-      name: "itt-provider"
+      id: "former-itt-provider",
+      name: "former-itt-provider"
+    }) }}
+  {% endset %}
+
+  {% set currentITTProviderNameHtml %}
+    {{ govukInput({
+      label: {
+        text: "Your school, university or other training provider"
+      },
+      id: "current-itt-provider",
+      name: "current-itt-provider"
     }) }}
   {% endset %}
 
@@ -34,12 +44,12 @@
             {
               text: "Yes, I completed my training",
               value: 'yes',
-              conditional: { html: ittProviderNameHtml }
+              conditional: { html: formerITTProviderNameHtml }
             },
             {
               text: "Yes, I’m currently in training",
               value: 'yes',
-              conditional: { html: ittProviderNameHtml }
+              conditional: { html: currentITTProviderNameHtml }
             },
             {
               text: "No",

--- a/app/views/name.njk
+++ b/app/views/name.njk
@@ -21,21 +21,17 @@ If your name has changed and you have not updated your Teaching Regulation Agenc
       <form method="post" novalidate>
       <h1 class="govuk-heading-xl">What is your name?</h1>
         <p class="govuk-body">First and last name exactly as it appears on the Teaching Regulation Agency records</p>
-        {{ govukInput({
+        {{ govukInput(decorate({
           label: {
             text: "First name"
-          },
-          id: "first-name",
-          name: "first-name"
-        }) }}
+          }
+        }, ['first-name'])) }}
 
-        {{ govukInput({
+        {{ govukInput(decorate({
           label: {
             text: "Last name"
-          },
-          id: "last-name",
-          name: "last-name"
-        }) }}
+          }
+        }, ['last-name'])) }}
 
         {{ govukDetails({
           summaryText: "Help if you have changed your name",

--- a/app/views/ni-number.njk
+++ b/app/views/ni-number.njk
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
-        {{ govukInput({
+        {{ govukInput(decorate({
           label: {
             text: "National Insurance number",
             classes: "govuk-label--xl",
@@ -22,10 +22,8 @@
             text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
           },
           classes: "govuk-input--width-10",
-          id: "national-insurance-number",
-          name: "national-insurance-number",
           spellcheck: false
-        }) }}
+        }, ["national-insurance-number"])) }}
 
         {{ govukButton({
           text: "Continue"


### PR DESCRIPTION
- the name, NINO and ITT provider pages now display previously entered values when going back to those pages (via the Back or Change links)
- the ITT provider is now displayed correctly on the 'Check your answers' page